### PR TITLE
Validate npm and zed package interoperability

### DIFF
--- a/.github/workflows/zed-package.yml
+++ b/.github/workflows/zed-package.yml
@@ -1,0 +1,78 @@
+name: Zed package interoperability
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  zed-package:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out package source
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          path: source
+          persist-credentials: false
+
+      - name: Check out pinned zed CLI
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          repository: zed-pkg/zed-cli
+          ref: cc1a8fbb203070ccfa09f32e38bff5818fd3675b
+          path: zed-cli
+          persist-credentials: false
+
+      - name: Check out pinned zed interfaces
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          repository: zed-pkg/zed-interfaces
+          ref: 90534dd8468d98281356f2767f1a0b498598f868
+          path: zed-interfaces
+          persist-credentials: false
+
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
+        with:
+          python-version: "3.12"
+
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30
+        with:
+          toolchain: stable
+
+      - name: Configure isolated pack output
+        run: echo "ZED_PACK_OUT=$RUNNER_TEMP/zed-pack" >> "$GITHUB_ENV"
+
+      - name: Pack r2g for zed cloud
+        working-directory: source
+        run: cargo run --quiet --locked --manifest-path ../zed-cli/Cargo.toml -- pack --out "$ZED_PACK_OUT"
+
+      - name: Verify zed and npm metadata ship together
+        working-directory: source
+        run: |
+          python3 - <<'PY'
+          import io
+          import os
+          import pathlib
+          import tarfile
+          import tomllib
+
+          out = pathlib.Path(os.environ["ZED_PACK_OUT"])
+          archives = list(out.glob("*.tar.gz"))
+          assert len(archives) == 1, f"expected one artifact, found {len(archives)}"
+          assert archives[0].name == "oresoftware-r2g-0.3.1.tar.gz"
+          with tarfile.open(archives[0], "r:gz") as packed:
+              names = set(packed.getnames())
+              assert "pkg/.zpkg.toml" in names
+              assert "pkg/package.json" in names
+              manifest = tomllib.load(io.BytesIO(packed.extractfile("pkg/.zpkg.toml").read()))
+          assert manifest["package"]["name"] == "r2g"
+          print("verified r2g zed artifact retains native npm metadata")
+          PY
+
+      - name: Exercise publish planning without uploading
+        working-directory: source
+        run: cargo run --quiet --locked --manifest-path ../zed-cli/Cargo.toml -- publish --dry-run --skip-vcs-checks

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ Dockerfile*
 .DS_Store
 Thumbs.db
 *.tsbuildinfo
+.zed-pack/
+.zed/

--- a/.zpkg.lock
+++ b/.zpkg.lock
@@ -1,0 +1,1 @@
+version = 1

--- a/.zpkg.toml
+++ b/.zpkg.toml
@@ -1,0 +1,20 @@
+[package]
+org = "oresoftware"
+name = "r2g"
+version = "0.3.1"
+description = "Prove packages work as real downstream dependencies before release"
+license = "MIT"
+keywords = ["package", "publishing", "downstream", "interoperability"]
+
+[package.repository]
+vcs = "git"
+url = "https://github.com/ORESoftware/r2g"
+
+[publish]
+include_readme = true
+tag_format = "v{version}"
+smoke_test = 'test -f "$ZED_PKG_TEST_TARGET/package.json"'
+exclude = [".env", ".env.*", ".direnv/**", ".zed-pack/**", "release/**", "**/*.log", ".DS_Store"]
+
+[scripts]
+test = "npm test"


### PR DESCRIPTION
## Summary

- make r2g publishable as a whole-repository zed package alongside npm
- retain npm as the native package manager and GitHub tags/releases as provenance
- add pinned CI that verifies `package.json` survives inside the zed artifact and runs a no-upload zed publish plan
- keep repository tests in `[scripts]` and use an artifact-safe zed downstream smoke check

## Validation

- `npm test` (19 tests)
- zed artifact packed and inspected locally
- workflow passes `actionlint`

The release workflow already publishes the tagged npm/GitHub artifacts; this PR adds zed-cloud readiness without exposing registry credentials in pull requests.
