### PR TITLE
Declare root npm and forge package routes

### DIFF
--- a/.github/workflows/zed-package.yml
+++ b/.github/workflows/zed-package.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with:
           repository: zed-pkg/zed-cli
-          ref: cc1a8fbb203070ccfa09f32e38bff5818fd3675b
+          ref: 5c5018a48f4f8da7daae94ec2eab99f17a6ffcef
           path: zed-cli
           persist-credentials: false
 
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with:
           repository: zed-pkg/zed-interfaces
-          ref: 90534dd8468d98281356f2767f1a0b498598f868
+          ref: dc0e0a0620b9462817950b552d3d334a184b1cb1
           path: zed-interfaces
           persist-credentials: false
 
@@ -72,6 +72,10 @@ jobs:
           assert manifest["package"]["name"] == "r2g"
           print("verified r2g zed artifact retains native npm metadata")
           PY
+
+      - name: Validate coordinated native and forge release plan
+        working-directory: source
+        run: cargo run --quiet --locked --manifest-path ../zed-cli/Cargo.toml -- release plan
 
       - name: Exercise publish planning without uploading
         working-directory: source

--- a/.zpkg.toml
+++ b/.zpkg.toml
@@ -16,5 +16,10 @@ tag_format = "v{version}"
 smoke_test = 'test -f "$ZED_PKG_TEST_TARGET/package.json"'
 exclude = [".env", ".env.*", ".direnv/**", ".zed-pack/**", "release/**", "**/*.log", ".DS_Store"]
 
+[publish.native]
+registry = "npm"
+package = "r2g"
+forge = ["github-packages", "gitlab-packages", "bitbucket-packages"]
+
 [scripts]
 test = "npm test"


### PR DESCRIPTION
## Summary

- use the new single-package `[publish.native]` shape to declare `r2g`'s canonical npm destination
- add compatible GitHub Packages, GitLab Package Registry, and Bitbucket Packages npm mirrors
- pin reviewed Zed interface/CLI commits and validate the root release plan in credential-free Actions

The same repository/version remains one Zed Cloud artifact and one native npm package with optional forge mirrors. No credentials or uploads are used.

Depends on zed-pkg/zed-interfaces#5 and zed-pkg/zed-cli#14.

## Validation

- `zed release plan --json` (1 Zed, 1 native, 3 forge routes)
- `zed release preflight` passed via `npm pack --dry-run --ignore-scripts`

Only `.zpkg.toml` and `.github/workflows/zed-package.yml` are included; unrelated local release-workflow changes were left untouched.